### PR TITLE
ENG-15361 Android Fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,9 +67,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
-    def ktor_version = "2.0.3"
-    implementation "io.ktor:ktor-client-core:$ktor_version"
-    implementation "io.ktor:ktor-client-cio:$ktor_version"
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
     implementation 'com.google.code.gson:gson:2.8.9'
 

--- a/android/src/main/java/com/vydia/RNUploader/ChunkUtils.kt
+++ b/android/src/main/java/com/vydia/RNUploader/ChunkUtils.kt
@@ -1,15 +1,12 @@
 package com.vydia.RNUploader
 
 import com.facebook.react.bridge.ReadableArray
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.*
 import java.io.RandomAccessFile
 import java.nio.channels.FileChannel
 
 
-class Chunk(val position: Long, val size: Long, val path: String) {
+data class Chunk(val position: Long, val size: Long, val path: String) {
   companion object {
     fun fromReactMethodParams(paramChunks: ReadableArray): List<Chunk> {
       val chunks = mutableListOf<Chunk>()
@@ -34,8 +31,8 @@ suspend fun chunkFile(
   scope: CoroutineScope,
   parentFilePath: String,
   chunks: List<Chunk>
-) {
-  val parentFile = scope.async(Dispatchers.IO) { RandomAccessFile(parentFilePath, "r") }.await()
+) = withContext(Dispatchers.IO) {
+  val parentFile = RandomAccessFile(parentFilePath, "r")
 
   chunks.map {
     scope.async(Dispatchers.IO) {

--- a/android/src/main/java/com/vydia/RNUploader/ChunkUtils.kt
+++ b/android/src/main/java/com/vydia/RNUploader/ChunkUtils.kt
@@ -11,7 +11,7 @@ import java.io.FileOutputStream
 
 data class Chunk(val position: Long, val size: Long, val path: String) {
   companion object {
-    fun fromReactMethodParams(paramChunks: ReadableArray): List<Chunk> {
+    fun fromReadableArray(paramChunks: ReadableArray): List<Chunk> {
       val chunks = mutableListOf<Chunk>()
       for (i in 0 until paramChunks.size()) {
         val paramChunk = paramChunks.getMap(i)

--- a/android/src/main/java/com/vydia/RNUploader/Upload.kt
+++ b/android/src/main/java/com/vydia/RNUploader/Upload.kt
@@ -24,14 +24,14 @@ data class Upload(
     IllegalArgumentException("Missing '$optionName'")
 
   companion object {
-    fun fromOptions(o: ReadableMap) = Upload(
-      id = o.getString("customUploadId") ?: UUID.randomUUID().toString(),
-      url = o.getString(Upload::url.name) ?: throw MissingOptionException(Upload::url.name),
-      path = o.getString(Upload::path.name) ?: throw MissingOptionException(Upload::path.name),
-      method = o.getString(Upload::method.name) ?: "POST",
-      maxRetries = if (o.hasKey(Upload::maxRetries.name)) o.getInt(Upload::maxRetries.name) else 5,
-      wifiOnly = if (o.hasKey(Upload::wifiOnly.name)) o.getBoolean(Upload::wifiOnly.name) else false,
-      headers = o.getMap(Upload::headers.name).let { headers ->
+    fun fromReadableMap(map: ReadableMap) = Upload(
+      id = map.getString("customUploadId") ?: UUID.randomUUID().toString(),
+      url = map.getString(Upload::url.name) ?: throw MissingOptionException(Upload::url.name),
+      path = map.getString(Upload::path.name) ?: throw MissingOptionException(Upload::path.name),
+      method = map.getString(Upload::method.name) ?: "POST",
+      maxRetries = if (map.hasKey(Upload::maxRetries.name)) map.getInt(Upload::maxRetries.name) else 5,
+      wifiOnly = if (map.hasKey(Upload::wifiOnly.name)) map.getBoolean(Upload::wifiOnly.name) else false,
+      headers = map.getMap(Upload::headers.name).let { headers ->
         if (headers == null) return@let mapOf()
         val map = mutableMapOf<String, String>()
         for (entry in headers.entryIterator) {
@@ -39,15 +39,15 @@ data class Upload(
         }
         return@let map
       },
-      notificationId = o.getString(Upload::notificationId.name)
+      notificationId = map.getString(Upload::notificationId.name)
         ?: throw MissingOptionException(Upload::notificationId.name),
-      notificationTitle = o.getString(Upload::notificationTitle.name)
+      notificationTitle = map.getString(Upload::notificationTitle.name)
         ?: throw MissingOptionException(Upload::notificationTitle.name),
-      notificationTitleNoInternet = o.getString(Upload::notificationTitleNoInternet.name)
+      notificationTitleNoInternet = map.getString(Upload::notificationTitleNoInternet.name)
         ?: throw MissingOptionException(Upload::notificationTitleNoInternet.name),
-      notificationTitleNoWifi = o.getString(Upload::notificationTitleNoWifi.name)
+      notificationTitleNoWifi = map.getString(Upload::notificationTitleNoWifi.name)
         ?: throw MissingOptionException(Upload::notificationTitleNoWifi.name),
-      notificationChannel = o.getString(Upload::notificationChannel.name)
+      notificationChannel = map.getString(Upload::notificationChannel.name)
         ?: throw MissingOptionException(Upload::notificationChannel.name),
     )
   }

--- a/android/src/main/java/com/vydia/RNUploader/Upload.kt
+++ b/android/src/main/java/com/vydia/RNUploader/Upload.kt
@@ -21,11 +21,14 @@ data class Upload(
   val notificationTitleNoWifi: String,
   val notificationChannel: String,
 ) {
+  class MissingOptionException(optionName: String) :
+    IllegalArgumentException("Missing '$optionName'")
+
   companion object {
     fun fromOptions(options: ReadableMap) = Upload(
       id = options.getString("customUploadId") ?: UUID.randomUUID().toString(),
-      url = options.getString("url") ?: throw InvalidUploadOptionException("Missing 'url'"),
-      path = options.getString("path") ?: throw InvalidUploadOptionException("Missing 'path'"),
+      url = options.getString("url") ?: throw MissingOptionException("url"),
+      path = options.getString("path") ?: throw MissingOptionException("path"),
       method = (options.getString("method") ?: "POST").let { HttpMethod.parse(it) },
       maxRetries = if (options.hasKey("maxRetries")) options.getInt("maxRetries") else 5,
       wifiOnly = if (options.hasKey("wifiOnly")) options.getBoolean("wifiOnly") else false,
@@ -38,18 +41,18 @@ data class Upload(
         return@let map
       },
       notificationId = options.getString("notificationId")
-        ?: throw InvalidUploadOptionException("Missing 'notificationId'"),
+        ?: throw MissingOptionException("notificationId"),
       notificationTitle = options.getString("notificationTitle")
-        ?: throw InvalidUploadOptionException("Missing 'notificationTitle'"),
+        ?: throw MissingOptionException("notificationTitle"),
       notificationTitleNoInternet = options.getString("notificationTitleNoInternet")
-        ?: throw InvalidUploadOptionException("Missing 'notificationTitleNoInternet'"),
+        ?: throw MissingOptionException("notificationTitleNoInternet"),
       notificationTitleNoWifi = options.getString("notificationTitleNoWifi")
-        ?: throw InvalidUploadOptionException("Missing 'notificationTitleNoWifi'"),
+        ?: throw MissingOptionException("notificationTitleNoWifi"),
       notificationChannel = options.getString("notificationChannel")
-        ?: throw InvalidUploadOptionException("Missing 'notificationChannel'"),
+        ?: throw MissingOptionException("notificationChannel"),
     )
   }
 }
 
 
-class InvalidUploadOptionException(message: String) : IllegalArgumentException(message)
+

--- a/android/src/main/java/com/vydia/RNUploader/Upload.kt
+++ b/android/src/main/java/com/vydia/RNUploader/Upload.kt
@@ -25,14 +25,14 @@ data class Upload(
     IllegalArgumentException("Missing '$optionName'")
 
   companion object {
-    fun fromOptions(options: ReadableMap) = Upload(
-      id = options.getString("customUploadId") ?: UUID.randomUUID().toString(),
-      url = options.getString("url") ?: throw MissingOptionException("url"),
-      path = options.getString("path") ?: throw MissingOptionException("path"),
-      method = (options.getString("method") ?: "POST").let { HttpMethod.parse(it) },
-      maxRetries = if (options.hasKey("maxRetries")) options.getInt("maxRetries") else 5,
-      wifiOnly = if (options.hasKey("wifiOnly")) options.getBoolean("wifiOnly") else false,
-      headers = options.getMap("headers").let { headers ->
+    fun fromOptions(o: ReadableMap) = Upload(
+      id = o.getString("customUploadId") ?: UUID.randomUUID().toString(),
+      url = o.getString(Upload::url.name) ?: throw MissingOptionException(Upload::url.name),
+      path = o.getString(Upload::path.name) ?: throw MissingOptionException(Upload::path.name),
+      method = (o.getString(Upload::method.name) ?: "POST").let { HttpMethod.parse(it) },
+      maxRetries = if (o.hasKey(Upload::maxRetries.name)) o.getInt(Upload::maxRetries.name) else 5,
+      wifiOnly = if (o.hasKey(Upload::wifiOnly.name)) o.getBoolean(Upload::wifiOnly.name) else false,
+      headers = o.getMap(Upload::headers.name).let { headers ->
         if (headers == null) return@let mapOf()
         val map = mutableMapOf<String, String>()
         for (entry in headers.entryIterator) {
@@ -40,16 +40,16 @@ data class Upload(
         }
         return@let map
       },
-      notificationId = options.getString("notificationId")
-        ?: throw MissingOptionException("notificationId"),
-      notificationTitle = options.getString("notificationTitle")
-        ?: throw MissingOptionException("notificationTitle"),
-      notificationTitleNoInternet = options.getString("notificationTitleNoInternet")
-        ?: throw MissingOptionException("notificationTitleNoInternet"),
-      notificationTitleNoWifi = options.getString("notificationTitleNoWifi")
-        ?: throw MissingOptionException("notificationTitleNoWifi"),
-      notificationChannel = options.getString("notificationChannel")
-        ?: throw MissingOptionException("notificationChannel"),
+      notificationId = o.getString(Upload::notificationId.name)
+        ?: throw MissingOptionException(Upload::notificationId.name),
+      notificationTitle = o.getString(Upload::notificationTitle.name)
+        ?: throw MissingOptionException(Upload::notificationTitle.name),
+      notificationTitleNoInternet = o.getString(Upload::notificationTitleNoInternet.name)
+        ?: throw MissingOptionException(Upload::notificationTitleNoInternet.name),
+      notificationTitleNoWifi = o.getString(Upload::notificationTitleNoWifi.name)
+        ?: throw MissingOptionException(Upload::notificationTitleNoWifi.name),
+      notificationChannel = o.getString(Upload::notificationChannel.name)
+        ?: throw MissingOptionException(Upload::notificationChannel.name),
     )
   }
 }

--- a/android/src/main/java/com/vydia/RNUploader/Upload.kt
+++ b/android/src/main/java/com/vydia/RNUploader/Upload.kt
@@ -1,7 +1,6 @@
 package com.vydia.RNUploader
 
 import com.facebook.react.bridge.ReadableMap
-import io.ktor.http.*
 import java.util.*
 
 // Data model of a single upload
@@ -11,7 +10,7 @@ data class Upload(
   val id: String,
   val url: String,
   val path: String,
-  val method: HttpMethod,
+  val method: String,
   val maxRetries: Int,
   val wifiOnly: Boolean,
   val headers: Map<String, String>,
@@ -29,7 +28,7 @@ data class Upload(
       id = o.getString("customUploadId") ?: UUID.randomUUID().toString(),
       url = o.getString(Upload::url.name) ?: throw MissingOptionException(Upload::url.name),
       path = o.getString(Upload::path.name) ?: throw MissingOptionException(Upload::path.name),
-      method = (o.getString(Upload::method.name) ?: "POST").let { HttpMethod.parse(it) },
+      method = o.getString(Upload::method.name) ?: "POST",
       maxRetries = if (o.hasKey(Upload::maxRetries.name)) o.getInt(Upload::maxRetries.name) else 5,
       wifiOnly = if (o.hasKey(Upload::wifiOnly.name)) o.getBoolean(Upload::wifiOnly.name) else false,
       headers = o.getMap(Upload::headers.name).let { headers ->

--- a/android/src/main/java/com/vydia/RNUploader/UploadUtils.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadUtils.kt
@@ -1,0 +1,79 @@
+package com.vydia.RNUploader
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.*
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import okio.Buffer
+import okio.BufferedSink
+import okio.ForwardingSink
+import okio.buffer
+import java.io.File
+import java.io.IOException
+import kotlin.coroutines.resumeWithException
+
+// Throttling interval of progress reports
+private const val PROGRESS_INTERVAL = 500 // milliseconds
+
+
+// make an upload request using okhttp
+suspend fun okhttpUpload(
+  client: OkHttpClient,
+  upload: Upload,
+  file: File,
+  onProgress: (Long) -> Unit
+) =
+  suspendCancellableCoroutine<Response> { continuation ->
+    val requestBody = file.asRequestBody(("application/octet-stream").toMediaType())
+    var lastProgressReport = 0L
+    fun throttled(): Boolean {
+      val now = System.currentTimeMillis()
+      if (now - lastProgressReport < PROGRESS_INTERVAL) return true
+      lastProgressReport = now
+      return false
+    }
+
+    val request = Request.Builder()
+      .url(upload.url)
+      .headers(upload.headers.toHeaders())
+      .method(upload.method, withProgressListener(requestBody) { progress ->
+        if (!throttled()) onProgress(progress)
+      })
+      .build()
+
+    val call = client.newCall(request)
+    continuation.invokeOnCancellation { call.cancel() }
+    call.enqueue(object : Callback {
+      override fun onFailure(call: Call, e: IOException) =
+        continuation.resumeWithException(e)
+
+      override fun onResponse(call: Call, response: Response) =
+        continuation.resumeWith(Result.success(response))
+    })
+  }
+
+// create a request body that allows us to listen to progress.
+// okhttp has no built-in way of reporting progress
+private fun withProgressListener(
+  body: RequestBody,
+  onProgress: (Long) -> Unit
+) = object : RequestBody() {
+  override fun contentType() = body.contentType()
+  override fun contentLength() = body.contentLength()
+  override fun writeTo(sink: BufferedSink) {
+    val countingSink = object : ForwardingSink(sink) {
+      var bytesWritten = 0L
+
+      override fun write(source: Buffer, byteCount: Long) {
+        super.write(source, byteCount)
+        bytesWritten += byteCount
+        onProgress(bytesWritten)
+      }
+    }
+
+    val bufferedSink = countingSink.buffer()
+    body.writeTo(bufferedSink)
+    bufferedSink.flush()
+  }
+}

--- a/android/src/main/java/com/vydia/RNUploader/UploadUtils.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadUtils.kt
@@ -3,7 +3,6 @@ package com.vydia.RNUploader
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.*
 import okhttp3.Headers.Companion.toHeaders
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.asRequestBody
 import okio.Buffer
 import okio.BufferedSink
@@ -25,7 +24,7 @@ suspend fun okhttpUpload(
   onProgress: (Long) -> Unit
 ) =
   suspendCancellableCoroutine<Response> { continuation ->
-    val requestBody = file.asRequestBody(("application/octet-stream").toMediaType())
+    val requestBody = file.asRequestBody()
     var lastProgressReport = 0L
     fun throttled(): Boolean {
       val now = System.currentTimeMillis()

--- a/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
@@ -123,6 +123,7 @@ class UploadWorker(private val context: Context, params: WorkerParameters) :
   private suspend fun upload(): HttpResponse? {
     val file = File(upload.path)
     val size = file.length()
+    if (size == 0L) throw Throwable("Invalid file size")
 
     // Register progress asap so the total progress is accurate
     // This needs to happen before the semaphore wait

--- a/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
@@ -30,12 +30,21 @@ private const val MAX_CONCURRENCY = 1
 // Retry delay
 private val RETRY_DELAY = TimeUnit.SECONDS.toMillis(10L)
 
+// Max total time for a single request to complete
+// This is 24hrs so plenty of time for large uploads
+// Worst case is the time maxes out and the upload gets restarted.
+// Not using unlimited time to prevent unexpected behaviors.
+private const val REQUEST_TIMEOUT = 24L
+private val REQUEST_TIMEOUT_UNIT = TimeUnit.HOURS
+
 // Control max concurrent requests using semaphore to instead of using
 // `maxConnectionsCount` in HttpClient as the latter introduces a delay between requests
 private val semaphore = Semaphore(MAX_CONCURRENCY)
 
 // Use Okhttp as it provides the most standard behaviors even though it's not coroutine friendly
-private val client = OkHttpClient()
+private val client = OkHttpClient.Builder()
+  .callTimeout(REQUEST_TIMEOUT, REQUEST_TIMEOUT_UNIT)
+  .build()
 
 private enum class Connectivity { NoWifi, NoInternet, Ok }
 

--- a/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
@@ -236,8 +236,8 @@ class UploadWorker(private val context: Context, params: WorkerParameters) :
     val notification = NotificationCompat.Builder(context, channel).run {
       // Starting Android 12, the notification shows up with a confusing delay of 10s.
       // This fixes that delay.
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) foregroundServiceBehavior =
-        Notification.FOREGROUND_SERVICE_IMMEDIATE
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+        foregroundServiceBehavior = Notification.FOREGROUND_SERVICE_IMMEDIATE
 
       // Required by android. Here we use the system's default upload icon
       setSmallIcon(android.R.drawable.stat_sys_upload)

--- a/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploadWorker.kt
@@ -76,10 +76,19 @@ class UploadWorker(private val context: Context, params: WorkerParameters) :
     var isRetried = false
     while (true) {
       try {
-        // Delay if it's an actual retry.
-        // Should be within the try block to account for worker cancellation,
-        // which resumes immediately and throws CancellationException.
-        if (isRetried) delay(RETRY_DELAY)
+        // - Delay if it's an actual retry.
+        if (isRetried) {
+          // - "delay" should be within the "try" block to account for worker cancellation,
+          // which cancels the delay immediately and throws CancellationException.
+          // - Linear backoff instead of exponential
+          // One reason for this is we retry on invalid connections. Exponential will
+          // take too long. If the server flakes and returns 500s, we don't retry but consider
+          // the request successful. This is consistent with iOS behavior.
+          // User gets notifications for these server issues and can manually retry.
+          // Since 500s are currently rare, it's likely ok. If they're too frequent,
+          // we can consider adding exponential backoff for them.
+          delay(RETRY_DELAY)
+        }
         isRetried = true
 
         val response = upload() ?: continue

--- a/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
@@ -38,7 +38,7 @@ class UploaderModule(context: ReactApplicationContext) :
   fun chunkFile(parentFilePath: String, chunks: ReadableArray, promise: Promise) {
     CoroutineScope(Dispatchers.IO).launch {
       try {
-        chunkFile(this, parentFilePath, Chunk.fromReactMethodParams(chunks))
+        chunkFile(parentFilePath, Chunk.fromReactMethodParams(chunks))
         promise.resolve(true)
       } catch (e: Throwable) {
         promise.reject(e)

--- a/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
@@ -38,7 +38,7 @@ class UploaderModule(context: ReactApplicationContext) :
   fun chunkFile(parentFilePath: String, chunks: ReadableArray, promise: Promise) {
     CoroutineScope(Dispatchers.IO).launch {
       try {
-        chunkFile(parentFilePath, Chunk.fromReactMethodParams(chunks))
+        chunkFile(parentFilePath, Chunk.fromReadableArray(chunks))
         promise.resolve(true)
       } catch (e: Throwable) {
         promise.reject(e)
@@ -69,7 +69,7 @@ class UploaderModule(context: ReactApplicationContext) :
    * @return whether the upload was started
    */
   private fun startUpload(options: ReadableMap): String {
-    val upload = Upload.fromOptions(options)
+    val upload = Upload.fromReadableMap(options)
     val data = Gson().toJson(upload)
 
     val request = OneTimeWorkRequestBuilder<UploadWorker>()

--- a/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
@@ -57,7 +57,7 @@ class UploaderModule(context: ReactApplicationContext) :
       val id = startUpload(rawOptions)
       promise.resolve(id)
     } catch (exc: Throwable) {
-      if (exc !is InvalidUploadOptionException) {
+      if (exc !is Upload.MissingOptionException) {
         exc.printStackTrace()
         Log.e(TAG, exc.message, exc)
       }


### PR DESCRIPTION
During my testing, I found a couple of non-standard behaviors with `ktor`, the http request library we use with `CoroutineWorker`, like hanging indefinitely when the BE sends back an upload error or bypassing network proxy. This proves that `ktor` has not yet matured and may have more non-standard behaviors unknown to us yet.

We originally picked this library because it works well with coroutine and it has very simple interfaces. However it has proven to be not yet mature, so we need to go back to `okhttp` and retrofit so `okhttp` works with coroutine.

### Test Plan
 - Use the Mock Recording tool to create a BG upload that will return an error. The upload should stop and report errors.