### PR TITLE
Fix "cancelled" emitted when an upload with the same ID is started

### DIFF
--- a/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
@@ -78,8 +78,11 @@ class UploaderModule(context: ReactApplicationContext) :
       .build()
 
     workManager
-      // cancel workers with duplicate ID
-      .beginUniqueWork(upload.id, ExistingWorkPolicy.REPLACE, request)
+      // Using KEEP policy to prevent it from cancelling the work if it's already running.
+      // Otherwise, it will emit "cancelled" and then go on to emit "progress" events,
+      // which is confusing and quite difficult to manage. "cancelled" should be reserved for
+      // when the user explicitly cancels the upload.
+      .beginUniqueWork(upload.id, ExistingWorkPolicy.KEEP, request)
       .enqueue()
 
     return upload.id


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

See code comment for more details

## Test Plan

Upload should not emit "cancelled" when a new upload with the same ID is created


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |


