### PR TITLE
Sync kotlin and java version to 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,8 +52,12 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
# Summary

This syncs the kotlin and java source and compile versions to 17. A RN 0.73 upgrade in Diana is causing this error message in this library when running Diana `yarn android`:

```
Execution failed for task ':react-native-background-upload:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version. Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```

I've tried syncing to 18 but can't get that to work. I believe RN 0.73 [recommends JDK 17 anyway](https://reactnative.dev/docs/environment-setup)
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
