### PR TITLE
Fix upload issues on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,6 @@ Note: if you are installing on React Native < 0.47, use `react-native-background
 
 `cd ./ios && pod install && cd ../`
 
-### Android
-
-If your app targets Android 14 (API 34) or higher, you need to add the following permissions to your AndroidManifest.xml:
-
-```xml
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
-<application>
-  ...
-  <service
-          android:name="androidx.work.impl.foreground.SystemForegroundService"
-          android:foregroundServiceType="dataSync"
-          tools:node="merge" />
-  ...
-</application>
-```
-
 ## 3. Expo
 
 To use this library with [Expo](https://expo.io) one must first detach (eject) the project and follow [step 2](#2-link-native-code) instructions. Additionally on iOS there is a must to add a Header Search Path to other dependencies which are managed using Pods. To do so one has to add `$(SRCROOT)/../../../ios/Pods/Headers/Public` to Header Search Path in `VydiaRNFileUploader` module using XCode.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,28 @@ Documentation has been modified to reflect the changes made to this library.
 
 Note: if you are installing on React Native < 0.47, use `react-native-background-upload@3.0.0` instead of `react-native-background-upload`
 
-## 2. Link Native Code
+## 2. Native Setup
 
-### Autolinking (React Native >= 0.60)
-
-##### iOS
+### iOS
 
 `cd ./ios && pod install && cd ../`
+
+### Android
+
+If your app targets Android 14 (API 34) or higher, you need to add the following permissions to your AndroidManifest.xml:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+<application>
+  ...
+  <service
+          android:name="androidx.work.impl.foreground.SystemForegroundService"
+          android:foregroundServiceType="dataSync"
+          tools:node="merge" />
+  ...
+</application>
+```
 
 ## 3. Expo
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,8 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.vydia.RNUploader">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.vydia.RNUploader">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <application>
         <receiver android:name=".NotificationReceiver" />
+        <service
+                android:name="androidx.work.impl.foreground.SystemForegroundService"
+                android:foregroundServiceType="dataSync"
+                tools:node="merge" />
     </application>
 </manifest>

--- a/example/RNBackgroundExample/android/app/build.gradle
+++ b/example/RNBackgroundExample/android/app/build.gradle
@@ -121,7 +121,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -130,8 +130,8 @@ android {
 
     defaultConfig {
         applicationId "com.rnbackgroundexample"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type

--- a/example/RNBackgroundExample/android/app/src/main/AndroidManifest.xml
+++ b/example/RNBackgroundExample/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.rnbackgroundexample">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -7,6 +8,8 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <application
       android:name=".MainApplication"
@@ -21,13 +24,18 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <service
+        android:name="androidx.work.impl.foreground.SystemForegroundService"
+        android:foregroundServiceType="dataSync"
+        tools:node="merge" />
     </application>
 
 </manifest>

--- a/example/RNBackgroundExample/android/build.gradle
+++ b/example/RNBackgroundExample/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 24
-        compileSdkVersion = 31
-        targetSdkVersion = 29
+        compileSdkVersion = 34
+        targetSdkVersion = 34
         ext.kotlinVersion = '1.8.0' // Your app's version
         ext.detoxKotlinVersion = ext.kotlinVersion // Detox' version: should be 1.1.0 or higher!
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "7.4.1",
+  "version": "7.5.0",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

## Android 14
Add support for Android 14 which requires a "foreground service type" to be declared in `AndroidManifest.xml` and used when `setForeground()`. Otherwise, the app will crash upon upload starts.

## Retry on flaky I/O errors

I/O errors happen quite often due to flaky network and file read operations on android and they are buried inside a sentry issue titled "Timed out", which is archived due to its misleading name, but inside it merges a bunch of different titles. Below is some stats of those issues. This PR adds unlimited retry capability for flaky I/O issues and shall exit if it's an unrecoverable one.

```
 'Unable to resolve host': 21078,
  'I/O error during system call': 4666,
  'Error: stream was reset: NO_ERROR': 325,
  'Error: Broken pipe': 18350,
  'Error: startForegroundService() not allowed due to mAllowStartForeground false: service ai.openspace.Cap...': 1636,
  'Error: timeout': 3029,
  'Error: Read timed out': 56,
  'Error: socket failed: EPERM (Operation not permitted)': 4,
  'Open file failed': 745,
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |


