### PR TITLE
Upgrade androidx.work:work-runtime-ktx:2.7.1 -> 2.8.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,5 +85,5 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
-    implementation "androidx.work:work-runtime-ktx:2.7.1"
+    implementation "androidx.work:work-runtime-ktx:2.8.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,5 +85,5 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
-    implementation "androidx.work:work-runtime-ktx:2.8.0"
+    implementation "androidx.work:work-runtime-ktx:2.8.1"
 }


### PR DESCRIPTION
This should be fine as this has been automatically done for our main project for ages due the versions on OneSignal and Notifee being higher

If you run this
```sh
./gradlew :app:dependencyInsight \
  --configuration devDebugRuntimeClasspath \
  --dependency androidx.work:work-runtime
```

it shows 
```sh
androidx.work:work-runtime-ktx:2.7.1 -> 2.8.1
\--- project :react-native-background-upload
     \--- devDebugRuntimeClasspath
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `androidx.work:work-runtime-ktx` from `2.7.1` to `2.8.1` in `android/build.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 826e3fdc6f85414d880c737bf2046c2f1c05f2ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->